### PR TITLE
Fixed https://github.com/linq2db/t4models/issues/16

### DIFF
--- a/Templates/LinqToDB.ttinclude
+++ b/Templates/LinqToDB.ttinclude
@@ -431,7 +431,7 @@ void GenerateTypesFromMetadata()
 				spName += inputParameters.Count == 0 ? ");" : ",";
 
 				var hasOut = outputParameters.Any(pr => pr.IsOut);
-				var prefix = hasOut ? "var ret = " : "return ";
+				var prefix = hasOut ? "var __ret__ = " : "return ";
 
 				if (p.ResultTable == null)
 					p.Body.Add(prefix + "dataConnection.ExecuteProc(" + spName);
@@ -517,7 +517,7 @@ void GenerateTypesFromMetadata()
 					}
 
 					p.Body.Add("");
-					p.Body.Add("return ret;");
+					p.Body.Add("return __ret__;");
 				}
 			}
 


### PR DESCRIPTION
Method parameter ``@ret`` conflicts with ``ret`` variable.
Replacing latter with ``__ret__``.