### PR TITLE
Edit ConvertToCompilable for more strange name, included non letter or d...

### DIFF
--- a/Templates/DataModel.ttinclude
+++ b/Templates/DataModel.ttinclude
@@ -321,7 +321,10 @@ void LoadMetadata(DataConnection dataConnection)
 
 string ConvertToCompilable(string name)
 {
-	return name.Replace('.', '_').Replace(' ', '_');
+	var query = from c in name.ToCharArray()
+		        select (char.IsLetterOrDigit(c) || c == '@' ? c : '_');
+
+	return new string(query.ToArray());
 }
 
 Table GetTable(string name)


### PR DESCRIPTION
The correct name for the query, table or field in MS Access can include quotes and character № for example, which will not compilable. Please consider these changes to correct compile.