### PR TITLE
Optionally disable generate ITable<> objects for views

### DIFF
--- a/Templates/LinqToDB.ttinclude
+++ b/Templates/LinqToDB.ttinclude
@@ -22,7 +22,7 @@ bool? GeneratePrecisionProperty = null;
 bool? GenerateScaleProperty     = null;
 bool  GenerateDbTypes           = false;
 bool  GenerateSchemaAsType      = false;
-
+bool  GenerateViews              = true;
 string SchemaNameSuffix          = "Schema";
 string SchemaDataContextTypeName = "DataContext";
 
@@ -124,6 +124,10 @@ void GenerateTypesFromMetadata()
 		var props             = defProps;
 		var aliases           = defAliases;
 		var tableExtensions   = defTableExtensions;
+
+		if (t.IsView && !GenerateViews){
+			continue;
+		}
 
 		var schema = t.Schema != null && schemas.ContainsKey(t.Schema) ? schemas[t.Schema] : null;
 


### PR DESCRIPTION
Use the GenerateViews variable to enable/disable the generations of
ITable<> objects for view.
