### PR TITLE
Fixed invalid code generation

### DIFF
--- a/Templates/DataModel.ttinclude
+++ b/Templates/DataModel.ttinclude
@@ -194,7 +194,7 @@ void LoadServerMetadata(DataConnection dataConnection)
 								IsIdentity      = c.IsIdentity,
 								IsPrimaryKey    = c.IsPrimaryKey,
 								PrimaryKeyOrder = c.PrimaryKeyOrder,
-								MemberName      = CheckType(c.SystemType, c.MemberName),
+								MemberName      = CheckColumnName(CheckType(c.SystemType, c.MemberName)),
 								Type            = c.MemberType,
 								SkipOnInsert    = c.SkipOnInsert,
 								SkipOnUpdate    = c.SkipOnUpdate,
@@ -220,7 +220,7 @@ void LoadServerMetadata(DataConnection dataConnection)
 						IsOut         = pr.IsOut,
 						IsResult      = pr.IsResult,
 						Size          = pr.Size,
-						ParameterName = pr.ParameterName,
+						ParameterName = CheckParameterName(pr.ParameterName),
 						ParameterType = pr.ParameterType,
 						SystemType    = pr.SystemType,
 						DataType      = pr.DataType.ToString(),
@@ -268,6 +268,32 @@ string CheckType(Type type, string typeName)
 	if (!Model.Usings.Contains(type.Namespace))
 		Model.Usings.Add(type.Namespace);
 	return typeName;
+}
+
+string CheckColumnName(string memberName)
+{
+    if (string.IsNullOrEmpty(memberName))
+        memberName = "Empty";
+    else
+    {
+        memberName = memberName.Replace("%", "Percent");
+    }
+    return memberName;
+}
+
+string CheckParameterName(string parameterName)
+{
+    var invalidParameterNames = new List<string>
+    {
+        "@DataType"
+    };
+
+    var result = parameterName;
+    while (invalidParameterNames.Contains(result))
+    {
+        result = result + "_";
+    }
+	return result;
 }
 
 Action AfterLoadMetadata = () => {};


### PR DESCRIPTION
@DataType parameter name is not valid for C#
Some table procedures may return "%" column
