### PR TITLE
Fix normalization of all upper case names

### DIFF
--- a/Templates/DataModel.ttinclude
+++ b/Templates/DataModel.ttinclude
@@ -683,6 +683,15 @@ public class Parameter
 int _counter = 0;
 string ToValidName(string name, bool mayRemoveUnderscore = true)
 {
+	var anyUpper = NormalizeNames && name.Any(char.IsUpper);
+	// Pluralization of upper case word adds lower case 's' at the end of the word, which breaks intention of anyLower, so lets account for more than one lower char
+	//var anyLower = NormalizeNames && name.Any(char.IsUpper);
+	var anyLower = NormalizeNames && name.Count(char.IsLower) > 1;
+
+	// All uppers to lowers for normalization purposes
+	if (anyUpper && !anyLower)
+		name = name.ToLower();
+
 	if (NormalizeNames && mayRemoveUnderscore && name.Contains("_"))
 	{
 		name = SplitAndJoin(name, "", '_');


### PR DESCRIPTION
Given: NormalizeNames = true, table name "MY_COOL_NAME".
run GenerateModel()
Expected result: class name is MyCoolName.
Actual result: class name is MYCOOLNAME.

Proposed change fixes one use case: MY_COOL_NAME --> MyCoolName. No tests have been performed for backward compatibility or breaking changes for other user cases.