### PR TITLE
Added several template improvements to avoid generation of duplicates

### DIFF
--- a/Templates/DataModel.ttinclude
+++ b/Templates/DataModel.ttinclude
@@ -83,6 +83,18 @@ static Func<ColumnSchema,string>                 ConvertColumnMemberType        
 static Func<TableSchema,ColumnSchema,string>     ConvertTableColumnMemberType     = (t,c) => ConvertColumnMemberType(c);
 static Func<ProcedureSchema,ColumnSchema,string> ConvertProcedureColumnMemberType = (t,c) => ConvertColumnMemberType(c);
 
+HashSet<string> KeyWords = new HashSet<string>
+{
+	"abstract", "as",       "base",     "bool",    "break",     "byte",     "case",       "catch",     "char",    "checked",
+	"class",    "const",    "continue", "decimal", "default",   "delegate", "do",         "double",    "else",    "enum",
+	"event",    "explicit", "extern",   "false",   "finally",   "fixed",    "float",      "for",       "foreach", "goto",
+	"if",       "implicit", "in",       "int",     "interface", "internal", "is",         "lock",      "long",    "new",
+	"null",     "object",   "operator", "out",     "override",  "params",   "private",    "protected", "public",  "readonly",
+	"ref",      "return",   "sbyte",    "sealed",  "short",     "sizeof",   "stackalloc", "static",    "struct",  "switch",
+	"this",     "throw",    "true",     "try",     "typeof",    "uint",     "ulong",      "unchecked", "unsafe",  "ushort",
+	"using",    "virtual",  "volatile", "void",    "while",     "namespace", "string"
+};
+
 void LoadServerMetadata(DataConnection dataConnection)
 {
 	SqlBuilder = dataConnection.DataProvider.CreateSqlBuilder();
@@ -114,12 +126,8 @@ void LoadServerMetadata(DataConnection dataConnection)
 				Schema                  = (t.IsDefaultSchema && !IncludeDefaultSchema) || string.IsNullOrEmpty(t.SchemaName)? null : t.SchemaName,
 				BaseClass               = BaseEntityClass,
 				TableName               = t.TableName,
-				TypeName                =
-					PluralizeClassNames   ? ToPlural  (t.TypeName) :
-					SingularizeClassNames ? ToSingular(t.TypeName) : t.TypeName,
-				DataContextPropertyName =
-					PluralizeDataContextPropertyNames   ? ToPlural  (t.TypeName) :
-					SingularizeDataContextPropertyNames ? ToSingular(t.TypeName) : t.TypeName,
+				TypeName                = t.TypeName,
+				DataContextPropertyName = t.TypeName,
 				IsView                  = t.IsView,
 				IsProviderSpecific      = false,
 				Description             = t.Description,
@@ -146,6 +154,48 @@ void LoadServerMetadata(DataConnection dataConnection)
 			}
 		})
 		.ToList();
+
+	if (PluralizeClassNames || SingularizeClassNames)
+	{
+		var foundNames = new HashSet<string>(tables.Select(t => t.table.TypeName));
+		foreach (var t in tables)
+		{
+			var newName = t.table.TypeName;
+				newName = 
+					PluralizeClassNames   ? ToPlural  (newName) :
+					SingularizeClassNames ? ToSingular(newName) : newName;
+
+			if (newName != t.table.TypeName)
+			{
+				if (!foundNames.Contains(newName))
+				{
+					t.table.TypeName = newName;
+					foundNames.Add(newName);
+				}
+			}
+		}
+	}
+
+	if (PluralizeDataContextPropertyNames || SingularizeDataContextPropertyNames)
+	{
+		var foundNames = new HashSet<string>(tables.Select(t => t.table.DataContextPropertyName));
+		foreach (var t in tables)
+		{
+			var newName = t.table.DataContextPropertyName;
+				newName = 
+					PluralizeDataContextPropertyNames   ? ToPlural  (newName) :
+					SingularizeDataContextPropertyNames ? ToSingular(newName) : newName;
+
+			if (newName != t.table.TypeName)
+			{
+				if (!foundNames.Contains(newName))
+				{
+					t.table.DataContextPropertyName = newName;
+					foundNames.Add(newName);
+				}
+			}
+		}
+	}
 
 	tables.AddRange(db.Tables
 		.Where(t => t.IsProviderSpecific)
@@ -185,17 +235,21 @@ void LoadServerMetadata(DataConnection dataConnection)
 
 	foreach (var key in keys)
 	{
+	    var keyName = key.k.OtherTable.IsDefaultSchema ? key.KeyName : key.k.OtherTable.SchemaName + "." + key.KeyName;
+		ForeignKey foundKey;
+		if (key.t.table.ForeignKeys.TryGetValue(keyName, out foundKey))
+		{
+			key.t.table.ForeignKeys.Remove(keyName);
+			key.t.table.ForeignKeys.Add(foundKey.OtherTable.TableName + "." + keyName, foundKey);
+			keyName = key.k.OtherTable.TableName + "." + keyName;
+		}
+
 		key.t.table.ForeignKeys.Add(
 			key.k.OtherTable.IsDefaultSchema ? key.KeyName : key.k.OtherTable.SchemaName + "." + key.KeyName,
 			key.key);
 
 		if (key.k.BackReference != null)
 			key.key.BackReference = keys.First(k => k.k == key.k.BackReference).key;
-
-		key.key.MemberName = key.key.MemberName.Replace(".", String.Empty);
-
-		key.key.MemberName = key.key.AssociationType == AssociationType.OneToMany ?
-			ToPlural(key.key.MemberName) : ToSingular(key.key.MemberName);
 	}
 
 	var procedures = db.Procedures
@@ -326,8 +380,8 @@ string CheckColumnName(string memberName)
 			.Replace(".", "_")
 			.Replace("\u00A3", "Pound");
 	
-		if (memberName == "new")
-			memberName = "@new";
+		if (KeyWords.Contains(memberName))
+			memberName = "@" + memberName;
     }
     return memberName;
 }
@@ -363,24 +417,12 @@ void LoadMetadata(DataConnection dataConnection)
 	if (Tables.Values.SelectMany(_ => _.ForeignKeys.Values).Any(_ => _.AssociationType == AssociationType.OneToMany))
 		Model.Usings.Add("System.Collections.Generic");
 
-	var keyWords = new HashSet<string>
-	{
-		"abstract", "as",       "base",     "bool",    "break",     "byte",     "case",       "catch",     "char",    "checked",
-		"class",    "const",    "continue", "decimal", "default",   "delegate", "do",         "double",    "else",    "enum",
-		"event",    "explicit", "extern",   "false",   "finally",   "fixed",    "float",      "for",       "foreach", "goto",
-		"if",       "implicit", "in",       "int",     "interface", "internal", "is",         "lock",      "long",    "new",
-		"null",     "object",   "operator", "out",     "override",  "params",   "private",    "protected", "public",  "readonly",
-		"ref",      "return",   "sbyte",    "sealed",  "short",     "sizeof",   "stackalloc", "static",    "struct",  "switch",
-		"this",     "throw",    "true",     "try",     "typeof",    "uint",     "ulong",      "unchecked", "unsafe",  "ushort",
-		"using",    "virtual",  "volatile", "void",    "while",     "namespace", "string"
-	};
-
 	foreach (var t in Tables.Values)
 	{
-		if (keyWords.Contains(t.TypeName))
+		if (KeyWords.Contains(t.TypeName))
 			t.TypeName = "@" + t.TypeName;
 
-		if (keyWords.Contains(t.DataContextPropertyName))
+		if (KeyWords.Contains(t.DataContextPropertyName))
 			t.DataContextPropertyName = "@" + t.DataContextPropertyName;
 
 		t.TypeName                = ConvertToCompilable(t.TypeName,                true);
@@ -388,7 +430,7 @@ void LoadMetadata(DataConnection dataConnection)
 
 		foreach (var col in t.Columns.Values)
 		{
-			if (keyWords.Contains(col.MemberName))
+			if (KeyWords.Contains(col.MemberName))
 				col.MemberName = "@" + col.MemberName;
 
 			col.MemberName = ConvertToCompilable(col.MemberName, true);
@@ -396,32 +438,89 @@ void LoadMetadata(DataConnection dataConnection)
 			if (col.MemberName == t.TypeName)
 				col.MemberName += "_Column";
 		}
+	}
 
-	    var duplicates = t.Columns.Values.ToLookup(c => c.MemberName).Where(g => g.Count() > 1);
-	    foreach (var d in duplicates)
-	    {
-			var alreadyNamed = new HashSet<string>();
-	        foreach (var col in d)
-	        {
-	            col.MemberName = col.ColumnName;
-	            if (keyWords.Contains(col.MemberName))
-	                col.MemberName = "@" + col.MemberName;
+	foreach (var t in Tables.Values)
+	{
+		foreach (var fk in t.ForeignKeys.Values)
+		{
+			var memberName = fk.OtherTable.TypeName;
 
-	            col.MemberName = ConvertToCompilable(col.MemberName, false);
+			memberName = fk.AssociationType == AssociationType.OneToMany ?
+				ToPlural(memberName) : ToSingular(memberName);
 
-	            if (col.MemberName == t.TypeName)
-	                col.MemberName += "_Column";
+			fk.MemberName = memberName;
+		}
+	}
 
-	            while (alreadyNamed.Contains(col.MemberName))
-	            {
-	                col.MemberName += "_";
-	            }
-	            alreadyNamed.Add(col.MemberName);
-	        }
-	    }
+	foreach (var t in Tables.Values)
+	{
+		var hasDuplicates = t.Columns.Values
+				.Select(c => c.MemberName)
+				.Concat(t.ForeignKeys.Values.Select(f => f.MemberName))
+				.ToLookup(n => n)
+				.Any(g => g.Count() > 1);
+				
+		if (hasDuplicates)
+		{
+			foreach (var fk in t.ForeignKeys.Values)
+			{
+				var mayDuplicate = t.Columns.Values
+					.Select(c => c.MemberName)
+					.Concat(t.ForeignKeys.Values.Where(f => f != fk).Select(f => f.MemberName));
+
+				fk.MemberName = SuggestNoDuplicate(mayDuplicate, fk.MemberName, "FK");
+			}
+
+			foreach (var col in t.Columns.Values)
+			{
+				var mayDuplicate = t.Columns.Values
+					.Where(c => c != col)
+					.Select(c => c.MemberName)
+					.Concat(t.ForeignKeys.Values.Select(fk => fk.MemberName));
+
+				col.MemberName = SuggestNoDuplicate(mayDuplicate, col.MemberName, null);
+			}
+		}
 	}
 
 	AfterLoadMetadata();
+}
+
+string SuggestNoDuplicate(IEnumerable<string> currentNames, string newName, string prefix)
+{
+	var names = new HashSet<string>(currentNames);
+	var result = newName;
+	if (names.Contains(result))
+	{
+		if (!string.IsNullOrEmpty(prefix))
+			result = prefix + result;
+		if (names.Contains(result))
+		{
+			var counter = 0;
+			var number = string.Concat(result.Reverse().Take(6).TakeWhile(c => Char.IsDigit(c)).Reverse());
+			if (!string.IsNullOrEmpty(number))
+			{
+				if (int.TryParse(number, out counter))
+				{
+					result = result.Remove(result.Length - number.Length);
+				}
+			}
+			
+			do
+			{
+				++counter;
+				if (!names.Contains(result + counter))
+				{
+					result = result + counter;
+					break;
+				}
+			}
+			while(true);
+		}
+	}
+
+	return result;
 }
 
 string ConvertToCompilableDefault(string name, bool mayRemoveUnderscore)

--- a/Templates/LinqToDB.ttinclude
+++ b/Templates/LinqToDB.ttinclude
@@ -874,7 +874,9 @@ void GenerateTypesFromMetadata()
 
 string NormalizeStringName(string name)
 {
-	return @"@""" + name.Replace(@"""", @"""""") + @"""";
+	if (name.Contains("\"") || name.Contains("\\"))
+		return @"@""" + name.Replace(@"""", @"""""") + @"""";
+	return "\"" + name + "\"";
 }
 
 #>


### PR DESCRIPTION
All in one. These fixes helps to generate classes for our old database.

* Fixes https://github.com/linq2db/linq2db/issues/871
* Fixes situation when pluralization or singularization may generate duplicate members
* Improved naming of ForeignKeys - for now It is plural or singular name of reference type
* Improved duplicates resolving for columns
* Simplified column names (removed @ directive if not needed)

